### PR TITLE
add email tag and project tag to aws ec2 instances

### DIFF
--- a/components/aws/command/root.go
+++ b/components/aws/command/root.go
@@ -163,6 +163,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&gOpt.AWSAccessKeyID, "aws-access-key-id", "", "The access key used to operate against AWS resource")
 	rootCmd.PersistentFlags().StringVar(&gOpt.AWSSecretAccessKey, "aws-secret-access-key", "", "The secret access key used to operate against AWS resource")
 	rootCmd.PersistentFlags().StringVar(&gOpt.AWSRegion, "aws-region", "", "The default aws region ")
+	rootCmd.PersistentFlags().StringVar(&gOpt.TagEmail, "tag-email", "", "The email address used to tag the resource")
+	rootCmd.PersistentFlags().StringVar(&gOpt.TagProject, "tag-project", "", "The project name used to tag the resource")
 
 	_ = rootCmd.PersistentFlags().MarkHidden("native-ssh")
 	_ = rootCmd.PersistentFlags().MarkHidden("ssh-proxy-host")

--- a/pkg/aws/manager/deploy.go
+++ b/pkg/aws/manager/deploy.go
@@ -18,7 +18,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+
 	//	"path/filepath"
+	"strings"
+
 	"github.com/fatih/color"
 	"github.com/joomcode/errorx"
 	"github.com/luyomo/tisample/pkg/aws/clusterutil"
@@ -30,7 +33,7 @@ import (
 	"github.com/luyomo/tisample/pkg/executor"
 	"github.com/luyomo/tisample/pkg/logger"
 	"go.uber.org/zap"
-	"strings"
+
 	//	"github.com/luyomo/tisample/pkg/environment"
 	"github.com/luyomo/tisample/pkg/logger/log"
 	//	"github.com/luyomo/tisample/pkg/meta"
@@ -268,6 +271,8 @@ func (m *Manager) Deploy(
 
 	ctx := context.WithValue(context.Background(), "clusterName", name)
 	ctx = context.WithValue(ctx, "clusterType", "ohmytiup-tidb")
+	ctx = context.WithValue(ctx, "tagEmail", gOpt.TagEmail)
+	ctx = context.WithValue(ctx, "tagProject", gOpt.TagProject)
 
 	if err := t.Execute(ctxt.New(ctx, gOpt.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {

--- a/pkg/aws/manager/tidb.go
+++ b/pkg/aws/manager/tidb.go
@@ -159,6 +159,8 @@ func (m *Manager) TiDBDeploy(
 
 	ctx := context.WithValue(context.Background(), "clusterName", name)
 	ctx = context.WithValue(ctx, "clusterType", clusterType)
+	ctx = context.WithValue(ctx, "tagEmail", gOpt.TagEmail)
+	ctx = context.WithValue(ctx, "tagProject", gOpt.TagProject)
 	if err := t.Execute(ctxt.New(ctx, gOpt.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
 			// FIXME: Map possible task errors and give suggestions.
@@ -457,6 +459,8 @@ func (m *Manager) TiDBScale(
 	}
 	ctx := context.WithValue(context.Background(), "clusterName", name)
 	ctx = context.WithValue(ctx, "clusterType", clusterType)
+	ctx = context.WithValue(ctx, "tagEmail", gOpt.TagEmail)
+	ctx = context.WithValue(ctx, "tagProject", gOpt.TagProject)
 
 	cntEC2Nodes := base.AwsTopoConfigs.PD.Count + base.AwsTopoConfigs.TiDB.Count + base.AwsTopoConfigs.TiKV.Count + base.AwsTopoConfigs.DMMaster.Count + base.AwsTopoConfigs.DMWorker.Count + base.AwsTopoConfigs.TiCDC.Count
 	if cntEC2Nodes > 0 {

--- a/pkg/aws/manager/workstation.go
+++ b/pkg/aws/manager/workstation.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	// "strconv"
 	// "strings"
 	// "time"
@@ -31,6 +32,7 @@ import (
 	"github.com/luyomo/tisample/pkg/ctxt"
 	"github.com/luyomo/tisample/pkg/executor"
 	"github.com/luyomo/tisample/pkg/logger"
+
 	// "github.com/luyomo/tisample/pkg/logger/log"
 	"github.com/luyomo/tisample/pkg/meta"
 	"github.com/luyomo/tisample/pkg/set"
@@ -157,6 +159,8 @@ func (m *Manager) WorkstationDeploy(
 
 	ctx := context.WithValue(context.Background(), "clusterName", name)
 	ctx = context.WithValue(ctx, "clusterType", clusterType)
+	ctx = context.WithValue(ctx, "tagEmail", gOpt.TagEmail)
+	ctx = context.WithValue(ctx, "tagProject", gOpt.TagProject)
 
 	var workstationInfo task.ClusterInfo
 

--- a/pkg/aws/operation/operation.go
+++ b/pkg/aws/operation/operation.go
@@ -55,6 +55,10 @@ type Options struct {
 	AWSSecretAccessKey string // AWS_SECRET_ACCESS_KEY for aws cli
 	AWSRegion          string // AWS_REGION
 
+	// Tags for resource
+	TagEmail   string // email tag
+	TagProject string // project tag
+
 	// What type of things should we cleanup in clean command
 	CleanupData bool // should we cleanup data
 	CleanupLog  bool // should we clenaup log

--- a/pkg/aws/task/ec2.go
+++ b/pkg/aws/task/ec2.go
@@ -634,6 +634,8 @@ func (c *CreateTiKVNodes) Execute(ctx context.Context) error {
 		makeEc2Instance := &MakeEC2Instance{
 			clusterName:       clusterName,
 			clusterType:       clusterType,
+			tagEmail:          tagEmail,
+			tagProject:        tagProject,
 			subClusterType:    c.subClusterType,
 			componentName:     c.componentName,
 			clusterInfo:       c.clusterInfo,
@@ -757,6 +759,14 @@ func (c *MakeEC2Instance) Execute(ctx context.Context) error {
 		{
 			Key:   aws.String("Name"),
 			Value: aws.String(c.clusterName),
+		},
+		{
+			Key:   aws.String("Email"),
+			Value: aws.String(c.tagEmail),
+		},
+		{
+			Key:   aws.String("Project"),
+			Value: aws.String(c.tagProject),
 		},
 	}
 


### PR DESCRIPTION
usage
```
bin/aws --help 

...
      --tag-email string               The email address used to tag the resource
      --tag-project string             The project name used to tag the resource
```

exsample yaml
```
aws_topo_configs:
  general:
    imageid: ami-0f43aeb2debecd002	      # debian-10-amd64-daily-20220915-1139 # Image ID for TiDB cluster's EC2 node
    keyname: fuga.hoge.test.us-east-1
    keyfile: /Users/hoge-fuga/.ssh/fuga.hoge.test.us-east-1.pem
    cidr: 172.85.0.0/16                       # VPC cidr
    instance_type: m5.2xlarge                 # default instance type for EC2 nodes
    tidb_version: v6.1.1                      # TiDB version to deploy
  pd:
    instance_type: m5.2xlarge                 # PD instance type
    count: 3                                  # Number of PD nodes to generate
  tidb:
    instance_type: m5.2xlarge                 # TiDB instance type
    count: 2                                  # Number of TiDB nodes to generate
  tikv:
    instance_type: m5.2xlarge                 # TiKV instance type
    count: 3                                  # Number of TiKV nodes to generate
    volumeSize: 80                            # Volume Size of the TiKV nodes
workstation:
  cidr: 172.86.0.0/16
  instance_type: m5.2xlarge                 # default instance type for EC2 nodes
  keyname: fuga.hoge.test.us-east-1
  keyfile: /Users/hoge-fuga/.ssh/fuga.hoge.test.us-east-1.pem
  username: admin
  imageid: ami-0f43aeb2debecd002	          # debian-10-amd64-daily-20220915-1139 
  volumeSize: 300

```
exsample cli
```
./bin/aws tidb deploy test-hoge aws-tidb-medium.yaml --tag-email "fuga.hoge@pingcap.com" --tag-project foo
```

