### PR TITLE
rename tag name from Email to Owner

### DIFF
--- a/components/aws/command/root.go
+++ b/components/aws/command/root.go
@@ -163,7 +163,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&gOpt.AWSAccessKeyID, "aws-access-key-id", "", "The access key used to operate against AWS resource")
 	rootCmd.PersistentFlags().StringVar(&gOpt.AWSSecretAccessKey, "aws-secret-access-key", "", "The secret access key used to operate against AWS resource")
 	rootCmd.PersistentFlags().StringVar(&gOpt.AWSRegion, "aws-region", "", "The default aws region ")
-	rootCmd.PersistentFlags().StringVar(&gOpt.TagEmail, "tag-email", "", "The email address used to tag the resource")
+	rootCmd.PersistentFlags().StringVar(&gOpt.TagOwner, "tag-owner", "", "The email address used to tag the resource")
 	rootCmd.PersistentFlags().StringVar(&gOpt.TagProject, "tag-project", "", "The project name used to tag the resource")
 
 	_ = rootCmd.PersistentFlags().MarkHidden("native-ssh")

--- a/pkg/aws/manager/deploy.go
+++ b/pkg/aws/manager/deploy.go
@@ -271,7 +271,7 @@ func (m *Manager) Deploy(
 
 	ctx := context.WithValue(context.Background(), "clusterName", name)
 	ctx = context.WithValue(ctx, "clusterType", "ohmytiup-tidb")
-	ctx = context.WithValue(ctx, "tagEmail", gOpt.TagEmail)
+	ctx = context.WithValue(ctx, "tagOwner", gOpt.TagOwner)
 	ctx = context.WithValue(ctx, "tagProject", gOpt.TagProject)
 
 	if err := t.Execute(ctxt.New(ctx, gOpt.Concurrency)); err != nil {

--- a/pkg/aws/manager/tidb.go
+++ b/pkg/aws/manager/tidb.go
@@ -159,7 +159,7 @@ func (m *Manager) TiDBDeploy(
 
 	ctx := context.WithValue(context.Background(), "clusterName", name)
 	ctx = context.WithValue(ctx, "clusterType", clusterType)
-	ctx = context.WithValue(ctx, "tagEmail", gOpt.TagEmail)
+	ctx = context.WithValue(ctx, "tagOwner", gOpt.TagOwner)
 	ctx = context.WithValue(ctx, "tagProject", gOpt.TagProject)
 	if err := t.Execute(ctxt.New(ctx, gOpt.Concurrency)); err != nil {
 		if errorx.Cast(err) != nil {
@@ -459,7 +459,7 @@ func (m *Manager) TiDBScale(
 	}
 	ctx := context.WithValue(context.Background(), "clusterName", name)
 	ctx = context.WithValue(ctx, "clusterType", clusterType)
-	ctx = context.WithValue(ctx, "tagEmail", gOpt.TagEmail)
+	ctx = context.WithValue(ctx, "tagOwner", gOpt.TagOwner)
 	ctx = context.WithValue(ctx, "tagProject", gOpt.TagProject)
 
 	cntEC2Nodes := base.AwsTopoConfigs.PD.Count + base.AwsTopoConfigs.TiDB.Count + base.AwsTopoConfigs.TiKV.Count + base.AwsTopoConfigs.DMMaster.Count + base.AwsTopoConfigs.DMWorker.Count + base.AwsTopoConfigs.TiCDC.Count

--- a/pkg/aws/manager/workstation.go
+++ b/pkg/aws/manager/workstation.go
@@ -159,7 +159,7 @@ func (m *Manager) WorkstationDeploy(
 
 	ctx := context.WithValue(context.Background(), "clusterName", name)
 	ctx = context.WithValue(ctx, "clusterType", clusterType)
-	ctx = context.WithValue(ctx, "tagEmail", gOpt.TagEmail)
+	ctx = context.WithValue(ctx, "tagOwner", gOpt.TagOwner)
 	ctx = context.WithValue(ctx, "tagProject", gOpt.TagProject)
 
 	var workstationInfo task.ClusterInfo

--- a/pkg/aws/operation/operation.go
+++ b/pkg/aws/operation/operation.go
@@ -56,7 +56,7 @@ type Options struct {
 	AWSRegion          string // AWS_REGION
 
 	// Tags for resource
-	TagEmail   string // email tag
+	TagOwner   string // owner(emailaddress) tag
 	TagProject string // project tag
 
 	// What type of things should we cleanup in clean command


### PR DESCRIPTION
test command line
```
 ./bin/aws tidb deploy test-dzg aws-tidb-medium.yaml --tag-owner "fuga.hoge@pingcap.com" --tag-project Hoge
```

yaml
```
aws_topo_configs:
  general:
    imageid: ami-0f43aeb2debecd002	      # debian-10-amd64-daily-20220915-1139 # Image ID for TiDB cluster's EC2 node
    keyname: fuga.hoge.test.us-east-1
    keyfile: /Users/hoge-fuga/.ssh/fuga.hoge.test.us-east-1.pem
    cidr: 172.85.0.0/16                       # VPC cidr
    instance_type: m5.large                 # default instance type for EC2 nodes
    tidb_version: v6.1.1                      # TiDB version to deploy
  pd:
    instance_type: m5.large                 # PD instance type
    count: 3                                  # Number of PD nodes to generate
  tidb:
    instance_type: m5.large                 # TiDB instance type
    count: 2                                  # Number of TiDB nodes to generate
  tikv:
    instance_type: m5.large                 # TiKV instance type
    count: 3                                  # Number of TiKV nodes to generate
    volumeSize: 110                            # Volume Size of the TiKV nodes
workstation:
  cidr: 172.86.0.0/16
  instance_type: m5.large                 # default instance type for EC2 nodes
  keyname: fuga.hoge.test.us-east-1
  keyfile: /Users/hoge-fuga/.ssh/fuga.hoge.test.us-east-1.pem
  username: admin
  imageid: ami-0f43aeb2debecd002	          # debian-10-amd64-daily-20220915-1139 
  volumeSize: 300

```

![スクリーンショット 2022-09-22 23 43 09](https://user-images.githubusercontent.com/689799/191778229-810dff76-bb46-433c-8912-cc7c9a52d86b.png)
